### PR TITLE
Change the export to use the firebase-functions library to correctly register the function.

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ const EXT_MARKET_CAP = "/q/marketcap";
 const EXT_INTERVAL = "/q/interval";
 
 // [START Bitcoin Info]
-exports.bitcoinInfo = (req, res) => {
+const bitcoinInfo = (req, res) => {
   const assistant = new Assistant({request: req, response: res});
   console.log('bitcoinInfoAction Request headers: ' + JSON.stringify(req.headers));
   console.log('bitcoinInfoAction Request body: ' + JSON.stringify(req.body));
@@ -101,3 +101,5 @@ exports.bitcoinInfo = (req, res) => {
   assistant.handleRequest(actionMap);
 };
 // [END Bitcoin Info]
+const functions = require('firebase-functions');
+exports.bitcoinInfo = functions.https.onRequest( bitcoinInfo );


### PR DESCRIPTION
The original doesn't use firebase-functions to correctly create a function - it uses Google Cloud Functions, which has a slightly different registration format. This changes it to use Firebase Functions.